### PR TITLE
add ability to use libsecp256k1 for signing (supports RFC6979)

### DIFF
--- a/bitcoin/tests/test_wallet.py
+++ b/bitcoin/tests/test_wallet.py
@@ -11,11 +11,12 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import hashlib
 import unittest
 
 from bitcoin.core import b2x, x
 from bitcoin.core.script import CScript, IsLowDERSignature
-from bitcoin.core.key import CPubKey
+from bitcoin.core.key import CPubKey, is_libsec256k1_available, use_libsecp256k1_for_signing
 from bitcoin.wallet import *
 
 class Test_CBitcoinAddress(unittest.TestCase):
@@ -238,3 +239,57 @@ class Test_CBitcoinSecret(unittest.TestCase):
         hash = b'\x00' * 32
         with self.assertRaises(ValueError):
           sig = key.sign(hash[0:-2])
+
+
+class Test_RFC6979(unittest.TestCase):
+    def test(self):
+        if not is_libsec256k1_available():
+            return
+
+        use_libsecp256k1_for_signing(True)
+
+        # Test Vectors for RFC 6979 ECDSA, secp256k1, SHA-256
+        # (private key, message, expected k, expected signature)
+        test_vectors = [
+            (0x1, "Satoshi Nakamoto", 0x8F8A276C19F4149656B280621E358CCE24F5F52542772691EE69063B74F15D15, "934b1ea10a4b3c1757e2b0c017d0b6143ce3c9a7e6a4a49860d7a6ab210ee3d82442ce9d2b916064108014783e923ec36b49743e2ffa1c4496f01a512aafd9e5"),
+            (0x1, "All those moments will be lost in time, like tears in rain. Time to die...", 0x38AA22D72376B4DBC472E06C3BA403EE0A394DA63FC58D88686C611ABA98D6B3, "8600dbd41e348fe5c9465ab92d23e3db8b98b873beecd930736488696438cb6b547fe64427496db33bf66019dacbf0039c04199abb0122918601db38a72cfc21"),
+            (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140, "Satoshi Nakamoto", 0x33A19B60E25FB6F4435AF53A3D42D493644827367E6453928554F43E49AA6F90, "fd567d121db66e382991534ada77a6bd3106f0a1098c231e47993447cd6af2d06b39cd0eb1bc8603e159ef5c20a5c8ad685a45b06ce9bebed3f153d10d93bed5"),
+            (0xf8b8af8ce3c7cca5e300d33939540c10d45ce001b8f252bfbc57ba0342904181, "Alan Turing", 0x525A82B70E67874398067543FD84C83D30C175FDC45FDEEE082FE13B1D7CFDF1, "7063ae83e7f62bbb171798131b4a0564b956930092b33b07b395615d9ec7e15c58dfcc1e00a35e1572f366ffe34ba0fc47db1e7189759b9fb233c5b05ab388ea"),
+            (0xe91671c46231f833a6406ccbea0e3e392c76c167bac1cb013f6f1013980455c2, "There is a computer disease that anybody who works with computers knows about. It's a very serious disease and it interferes completely with the work. The trouble with computers is that you 'play' with them!", 0x1F4B84C23A86A221D233F2521BE018D9318639D5B8BBD6374A8A59232D16AD3D, "b552edd27580141f3b2a5463048cb7cd3e047b97c9f98076c32dbdf85a68718b279fa72dd19bfae05577e06c7c0c1900c371fcd5893f7e1d56a37d30174671f6")
+        ]
+        for vector in test_vectors:
+            secret = CBitcoinSecret.from_secret_bytes(x('{:064x}'.format(vector[0])))
+            encoded_sig = secret.sign(hashlib.sha256(vector[1].encode('utf8')).digest())
+
+            assert(encoded_sig[0] == 0x30)
+            assert(encoded_sig[1] == len(encoded_sig)-2)
+            assert(encoded_sig[2] == 0x02)
+
+            rlen = encoded_sig[3]
+            rpos = 4
+            assert(rlen in (32, 33))
+
+            if rlen == 33:
+                assert(encoded_sig[rpos] == 0)
+                rpos += 1
+                rlen -= 1
+
+            rval = encoded_sig[rpos:rpos+rlen]
+            spos = rpos+rlen
+            assert(encoded_sig[spos] == 0x02)
+
+            spos += 1
+            slen = encoded_sig[spos]
+            assert(slen in (32, 33))
+
+            spos += 1
+            if slen == 33:
+                assert(encoded_sig[spos] == 0)
+                spos += 1
+                slen -= 1
+
+            sval = encoded_sig[spos:spos+slen]
+            sig = b2x(rval + sval)
+            assert(str(sig) == vector[3])
+
+        use_libsecp256k1_for_signing(False)


### PR DESCRIPTION
This is done in a straightforward way, but it works for us.

Two new functions are added to core/key.py:

is_libsec256k1_available() -- to check that libsec256k1 is present
in the system

use_libsecp256k1_for_signing(do_use) - if do_use is True,
sign() function will use libsec256k1 (it will check
_libsecp256k1_enable_signing global flag)
if do_use is False, _libsecp256k1_enable_signing flag is set to False,
and openssl will be used within sign() function.