### PR TITLE
Fix DERSignature.stream_serialize length omission

### DIFF
--- a/bitcoin/signature.py
+++ b/bitcoin/signature.py
@@ -43,6 +43,7 @@ class DERSignature(ImmutableSerializable):
 
     def stream_serialize(self, f):
         f.write(b"\x30")
+        f.write(bytes([ len(r) + len(s) + 4 ]))
         f.write(b"\x02")
         BytesSerializer.stream_serialize(self.r, f)
         f.write(b"\x30")


### PR DESCRIPTION
DERSignature.stream_serialize does not write the remaining length of the message after the header byte.

This patch resolves the issue by writing the length of what remains to be written immediately after the header byte.

originally submitted by @m4burns to https://github.com/petertodd/python-bitcoinlib/pull/190